### PR TITLE
feat: new format for 'available-releases version'

### DIFF
--- a/pkg/multiwerf/available-releases.go
+++ b/pkg/multiwerf/available-releases.go
@@ -16,9 +16,11 @@ type AvailableReleasesInformer interface {
 	GetRelease(version string, channel string) (string, error)
 }
 
+// {"orderedChannels":[stable, ea, ...], orderedReleases: ["v1.1.0","v1.1.1-alpha.10"], releases:{"v1.1.0":[stable,ea], "v1.1.1-alpha.10":["alpha"]}}
 type AllChannelsReleasesInfo struct {
-	Channels []string          `json:"channels"`
-	Releases map[string]string `json:"releases"`
+	OrderedChannels []string            `json:"orderedChannels"`
+	OrderedReleases []string            `json:"orderedReleases"`
+	Releases        map[string][]string `json:"releases"`
 }
 
 type MainAvailableReleasesInformer struct {
@@ -40,11 +42,15 @@ func (m *MainAvailableReleasesInformer) GetMajorMinorReleases() ([]string, error
 
 // TODO
 func (m *MainAvailableReleasesInformer) GetAllChannelsReleases(version string) (info AllChannelsReleasesInfo, err error) {
-	releases, err := RemoteLatestChannelsReleases(version, m.Messages, m.BintrayClient)
+	orderedReleases, releases, err := RemoteLatestChannelsReleases(version, m.Messages, m.BintrayClient)
 	if err != nil {
 		return
 	}
-	return AllChannelsReleasesInfo{Channels: AvailableChannels, Releases: releases}, nil
+	return AllChannelsReleasesInfo{
+		OrderedChannels: AvailableChannelsStableFirst,
+		OrderedReleases: orderedReleases,
+		Releases:        releases,
+	}, nil
 }
 
 func (m *MainAvailableReleasesInformer) GetRelease(version string, channel string) (string, error) {

--- a/pkg/multiwerf/multiwerf.go
+++ b/pkg/multiwerf/multiwerf.go
@@ -17,6 +17,13 @@ var AvailableChannels = []string{
 	"ea",
 	"stable",
 }
+var AvailableChannelsStableFirst = []string{
+	"stable",
+	"ea",
+	"rc",
+	"beta",
+	"alpha",
+}
 
 // MultiwerfStorageDir is an effective path to a storage
 var MultiwerfStorageDir string
@@ -228,8 +235,8 @@ func AvailableReleases(version string, channel string, outputFormat string) (err
 				msg := ""
 				if outputFormat == "text" {
 					outMessages := []string{}
-					for _, channel := range releases.Channels {
-						outMessages = append(outMessages, fmt.Sprintf("%s %s", channel, releases.Releases[channel]))
+					for _, release := range releases.OrderedReleases {
+						outMessages = append(outMessages, fmt.Sprintf("%s %v", release, releases.Releases[release]))
 					}
 					msg = strings.Join(outMessages, "\n")
 				}


### PR DESCRIPTION
- output map: release -> array of labels