### PR TITLE
fix: empty werf path because of race between go routine and PrintMessages

### DIFF
--- a/pkg/multiwerf/multiwerf.go
+++ b/pkg/multiwerf/multiwerf.go
@@ -80,6 +80,8 @@ func Use(version string, channel string, forceRemoteCheck bool, args []string) (
 	// update multiwerf binary (self update)
 	go func() {
 		SelfUpdate(messages)
+		// Stop PrintMessages after return from SelfUpdate
+		messages <- ActionMessage{action: "exit"}
 	}()
 	err = PrintMessages(messages, script.Printer)
 	if err != nil {
@@ -113,6 +115,8 @@ func Use(version string, channel string, forceRemoteCheck bool, args []string) (
 	var binaryInfo BinaryInfo
 	go func() {
 		binaryInfo = binUpdater.GetLatestBinaryInfo(version, channel)
+		// Stop PrintMessages after return from GetLatestBinaryInfo
+		messages <- ActionMessage{action: "exit"}
 	}()
 	err = PrintMessages(messages, script.Printer)
 	if err != nil {
@@ -165,6 +169,8 @@ func Update(version string, channel string, args []string) (err error) {
 	go func() {
 		messages <- ActionMessage{msg: "Start SelfUpdate", debug: true}
 		SelfUpdate(messages)
+		// Stop PrintMessages after return from SelfUpdate
+		messages <- ActionMessage{action: "exit"}
 	}()
 	err = PrintMessages(messages, printer)
 	if err != nil {
@@ -175,7 +181,11 @@ func Update(version string, channel string, args []string) (err error) {
 	binUpdater := NewBinaryUpdater(messages)
 	binUpdater.SetRemoteEnabled(true)
 	binUpdater.SetRemoteDelayed(false)
-	go binUpdater.DownloadLatest(version, channel)
+	go func() {
+		binUpdater.DownloadLatest(version, channel)
+		// Stop PrintMessages after return from DownloadLatest
+		messages <- ActionMessage{action: "exit"}
+	}()
 	err = PrintMessages(messages, printer)
 	if err != nil {
 		return err

--- a/pkg/multiwerf/self-update.go
+++ b/pkg/multiwerf/self-update.go
@@ -30,7 +30,6 @@ func SelfUpdate(messages chan ActionMessage) {
 				stage:   "self-update"}
 		}
 	}
-	messages <- ActionMessage{action: "exit"}
 }
 
 func DoSelfUpdate(messages chan ActionMessage) string {

--- a/pkg/multiwerf/update.go
+++ b/pkg/multiwerf/update.go
@@ -65,7 +65,7 @@ func (u *MainBinaryUpdater) DownloadLatest(version string, channel string) (binI
 
 	remoteBinInfo, err := RemoteLatestBinaryInfo(version, channel, u.Messages, u.BintrayClient)
 	if err != nil {
-		u.Messages <- ActionMessage{err: err, action: "exit"}
+		u.Messages <- ActionMessage{err: err}
 		return
 	}
 
@@ -80,8 +80,7 @@ func (u *MainBinaryUpdater) DownloadLatest(version string, channel string) (binI
 		u.Messages <- ActionMessage{
 			comment: "no update needed",
 			msg:     fmt.Sprintf("%s %s/%s stays at %s", app.BintrayPackage, version, channel, latestVersion),
-			msgType: "ok",
-			action:  "exit"}
+			msgType: "ok"}
 		return
 	}
 
@@ -111,8 +110,7 @@ func (u *MainBinaryUpdater) DownloadLatest(version string, channel string) (binI
 	u.Messages <- ActionMessage{
 		comment: fmt.Sprintf("# update %s success", app.BintrayPackage),
 		msg:     fmt.Sprintf("%s %s/%s updated to %s", app.BintrayPackage, version, channel, latestVersion),
-		msgType: "ok",
-		action:  "exit"}
+		msgType: "ok"}
 
 	return binInfo
 }
@@ -211,8 +209,7 @@ func (u *MainBinaryUpdater) GetLatestBinaryInfo(version string, channel string) 
 			u.Messages <- ActionMessage{
 				comment: "no update needed",
 				msg:     fmt.Sprintf("%s %s/%s stays at %s", app.BintrayPackage, version, channel, localLatestVersion),
-				msgType: "ok",
-				action:  "exit"}
+				msgType: "ok"}
 			return localBinaryInfo
 		}
 		if remoteLatestVersion == "" && !localBinaryInfo.HashVerified {
@@ -255,8 +252,7 @@ func (u *MainBinaryUpdater) GetLatestBinaryInfo(version string, channel string) 
 		u.Messages <- ActionMessage{
 			comment: fmt.Sprintf("# update %s success", app.BintrayPackage),
 			msg:     fmt.Sprintf("%s %s/%s updated to %s", app.BintrayPackage, version, channel, remoteLatestVersion),
-			msgType: "ok",
-			action:  "exit"}
+			msgType: "ok"}
 		return newBinInfo
 	}
 


### PR DESCRIPTION
fixes #28 