### PR TITLE
More robust download, locks for operations

### DIFF
--- a/pkg/bintray/bintray.go
+++ b/pkg/bintray/bintray.go
@@ -18,8 +18,8 @@ type BintrayEvent struct {
 
 type BintrayClient interface {
 	GetPackage() (string, error)
-	DownloadRelease(version string, dstDir string, files map[string]string) error
-	FetchReleaseFile(version string, fileName string) (string, error)
+	DownloadFiles(version string, dstDir string, files map[string]string) error
+	GetFileContent(version string, fileName string) (string, error)
 	EventCh() chan BintrayEvent
 }
 
@@ -67,7 +67,7 @@ func GetPackageVersions(packageInfo string) (versions []string) {
 	return versions
 }
 
-func (bc *MainBintrayClient) DownloadRelease(version string, dstDir string, files map[string]string) error {
+func (bc *MainBintrayClient) DownloadFiles(version string, dstDir string, files map[string]string) error {
 	srcUrl := fmt.Sprintf("%s/%s/%s/%s", btDlUrl, bc.Subject, bc.Repo, version)
 
 	for fileType, fileName := range files {
@@ -85,7 +85,7 @@ func (bc *MainBintrayClient) DownloadRelease(version string, dstDir string, file
 	return nil
 }
 
-func (bc *MainBintrayClient) FetchReleaseFile(version string, fileName string) (string, error) {
+func (bc *MainBintrayClient) GetFileContent(version string, fileName string) (string, error) {
 	srcUrl := fmt.Sprintf("%s/%s/%s/%s", btDlUrl, bc.Subject, bc.Repo, version)
 	fileUrl := fmt.Sprintf("%s/%s", srcUrl, fileName)
 	return http.MakeRestAPICall("GET", fileUrl)

--- a/pkg/lock/base.go
+++ b/pkg/lock/base.go
@@ -1,0 +1,78 @@
+package lock
+
+import (
+	"time"
+)
+
+type Base struct {
+	Name        string
+	ActiveLocks int
+}
+
+type locker interface {
+	Lock() error
+	Unlock() error
+}
+
+type baseLocker struct {
+	Timeout  time.Duration
+	ReadOnly bool
+	OnWait   func(doWait func() error) error
+}
+
+func (locker *baseLocker) Lock() error {
+	panic("not implemented")
+}
+
+func (locker *baseLocker) Unlock() error {
+	panic("not implemented")
+}
+
+func (lock *Base) GetName() string {
+	return lock.Name
+}
+
+func (lock *Base) Lock(l locker) error {
+	if lock.ActiveLocks == 0 {
+		err := l.Lock()
+		if err != nil {
+			return err
+		}
+	}
+
+	lock.ActiveLocks += 1
+
+	return nil
+}
+
+func (lock *Base) Unlock(l locker) error {
+	if lock.ActiveLocks == 0 {
+		return nil
+	}
+
+	lock.ActiveLocks -= 1
+
+	if lock.ActiveLocks == 0 {
+		return l.Unlock()
+	}
+
+	return nil
+}
+
+func (lock *Base) WithLock(locker locker, f func() error) error {
+	var err error
+
+	err = lock.Lock(locker)
+	if err != nil {
+		return err
+	}
+
+	resErr := f()
+
+	err = lock.Unlock(locker)
+	if err != nil {
+		return err
+	}
+
+	return resErr
+}

--- a/pkg/lock/file_unix.go
+++ b/pkg/lock/file_unix.go
@@ -1,0 +1,144 @@
+// +build !windows
+
+package lock
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+func NewFileLock(name string, locksDir string) LockObject {
+	return &File{Base: Base{Name: name}, LocksDir: locksDir}
+}
+
+type File struct {
+	Base
+	LocksDir string
+	locker   *fileLocker
+}
+
+func (lock *File) newLocker(timeout time.Duration, readOnly bool, onWait func(doWait func() error) error) *fileLocker {
+	return &fileLocker{
+		baseLocker: baseLocker{
+			Timeout:  timeout,
+			ReadOnly: readOnly,
+			OnWait:   onWait,
+		},
+		FileLock: lock,
+	}
+}
+
+func (lock *File) Lock(timeout time.Duration, readOnly bool, onWait func(doWait func() error) error) error {
+	lock.locker = lock.newLocker(timeout, readOnly, onWait)
+	return lock.Base.Lock(lock.locker)
+}
+
+func (lock *File) Unlock() error {
+	if lock.locker == nil {
+		return nil
+	}
+
+	err := lock.Base.Unlock(lock.locker)
+	if err != nil {
+		return err
+	}
+
+	lock.locker = nil
+
+	return nil
+}
+
+func (lock *File) WithLock(timeout time.Duration, readOnly bool, onWait func(doWait func() error) error, f func() error) error {
+	lock.locker = lock.newLocker(timeout, readOnly, onWait)
+
+	err := lock.Base.WithLock(lock.locker, f)
+	if err != nil {
+		return err
+	}
+
+	lock.locker = nil
+
+	return nil
+}
+
+type fileLocker struct {
+	baseLocker
+
+	FileLock        *File
+	openFileHandler *os.File
+}
+
+func (locker *fileLocker) lockFilePath() string {
+	return filepath.Join(locker.FileLock.LocksDir, locker.FileLock.GetName())
+}
+
+func (locker *fileLocker) Lock() error {
+	f, err := os.OpenFile(locker.lockFilePath(), os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+
+	locker.openFileHandler = f
+
+	fd := int(locker.openFileHandler.Fd())
+	var mode int
+	if locker.ReadOnly {
+		mode = syscall.LOCK_SH
+	} else {
+		mode = syscall.LOCK_EX
+	}
+
+	err = syscall.Flock(fd, mode|syscall.LOCK_NB)
+
+	if err == syscall.EWOULDBLOCK {
+		return locker.OnWait(func() error {
+			return locker.pollFlock(fd, mode)
+		})
+	}
+
+	return err
+}
+
+func (locker *fileLocker) pollFlock(fd int, mode int) error {
+	flockRes := make(chan error)
+	cancelPoll := make(chan bool)
+
+	go func() {
+		ticker := time.NewTicker(time.Millisecond * 500)
+
+	PollFlock:
+		for {
+			select {
+			case <-ticker.C:
+				err := syscall.Flock(fd, mode|syscall.LOCK_NB)
+				if err == nil || err != syscall.EWOULDBLOCK {
+					flockRes <- err
+				}
+			case <-cancelPoll:
+				break PollFlock
+			}
+		}
+	}()
+
+	select {
+	case err := <-flockRes:
+		return err
+	case <-time.After(locker.Timeout):
+		cancelPoll <- true
+		return fmt.Errorf("lock `%s` timeout %s expired", locker.FileLock.GetName(), locker.Timeout)
+	}
+}
+
+func (locker *fileLocker) Unlock() error {
+	err := locker.openFileHandler.Close()
+	if err != nil {
+		return err
+	}
+
+	locker.openFileHandler = nil
+
+	return nil
+}

--- a/pkg/lock/file_windows.go
+++ b/pkg/lock/file_windows.go
@@ -1,0 +1,28 @@
+// +build windows
+
+package lock
+
+import (
+	"time"
+)
+
+func NewFileLock(name string, locksDir string) LockObject {
+	return &File{Base: Base{Name: name}, LocksDir: locksDir}
+}
+
+type File struct {
+	Base
+	LocksDir string
+}
+
+func (lock *File) Lock(timeout time.Duration, readOnly bool, onWait func(doWait func() error) error) error {
+	return nil
+}
+
+func (lock *File) Unlock() error {
+	return nil
+}
+
+func (lock *File) WithLock(timeout time.Duration, readOnly bool, onWait func(doWait func() error) error, f func() error) error {
+	return f()
+}

--- a/pkg/lock/lock.go
+++ b/pkg/lock/lock.go
@@ -1,0 +1,112 @@
+package lock
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+var (
+	LocksDir       string
+	Locks          map[string]LockObject
+	DefaultTimeout = 24 * time.Hour
+)
+
+func Init(path string) error {
+	Locks = make(map[string]LockObject)
+	LocksDir = filepath.Join(path, "locks")
+
+	err := os.MkdirAll(LocksDir, 0755)
+	if err != nil {
+		return fmt.Errorf("cannot initialize locks dir: %s", err)
+	}
+
+	return nil
+}
+
+type LockOptions struct {
+	Timeout  time.Duration
+	ReadOnly bool
+}
+
+func Lock(name string, opts LockOptions) error {
+	lock := getLock(name)
+
+	return lock.Lock(
+		getTimeout(opts), opts.ReadOnly,
+		func(doWait func() error) error { return onWait(name, doWait) },
+	)
+}
+
+type TryLockOptions struct {
+	ReadOnly bool
+}
+
+// TryLock tries to acquire a lock without a wait. Returns true if lock is acquired. Returns false if lock is acquired by another process.
+func TryLock(name string, opts TryLockOptions) (bool, error) {
+	res := true
+	lock := getLock(name)
+
+	err := lock.Lock(0, opts.ReadOnly, func(doWait func() error) error {
+		// Wait called => is locked now, do not call doWait, just return
+		res = false
+		return nil
+	})
+
+	if err != nil {
+		return false, err
+	}
+
+	return res, nil
+}
+
+func Unlock(name string) error {
+	if _, hasKey := Locks[name]; !hasKey {
+		return fmt.Errorf("no such lock `%s` found", name)
+	}
+
+	lock := getLock(name)
+
+	return lock.Unlock()
+}
+
+func WithLock(name string, opts LockOptions, f func() error) error {
+	lock := getLock(name)
+
+	return lock.WithLock(
+		getTimeout(opts), opts.ReadOnly,
+		func(doWait func() error) error { return onWait(name, doWait) },
+		f,
+	)
+}
+
+func onWait(name string, doWait func() error) error {
+	//logProcessMsg := fmt.Sprintf("Waiting for locked resource '%s'", name)
+	// log.Debug(logProcessMsg)
+	return doWait()
+}
+
+func getTimeout(opts LockOptions) time.Duration {
+	if opts.Timeout != 0 {
+		return opts.Timeout
+	}
+	return DefaultTimeout
+}
+
+func getLock(name string) LockObject {
+	if l, hasKey := Locks[name]; hasKey {
+		return l
+	}
+
+	Locks[name] = NewFileLock(name, LocksDir)
+
+	return Locks[name]
+}
+
+type LockObject interface {
+	GetName() string
+	Lock(timeout time.Duration, readOnly bool, onWait func(doWait func() error) error) error
+	Unlock() error
+	WithLock(timeout time.Duration, readOnly bool, onWait func(doWait func() error) error, f func() error) error
+}

--- a/pkg/multiwerf/file_test.go
+++ b/pkg/multiwerf/file_test.go
@@ -25,6 +25,6 @@ func Test_VerifyReleaseFileHash(t *testing.T) {
 	assert.True(t, verified)
 
 	verified, err = VerifyReleaseFileHash("testdata", "SHA256SUMS", "non-existent")
-	assert.NoError(t, err)
+	assert.Error(t, err)
 	assert.False(t, verified)
 }

--- a/pkg/multiwerf/self-update.go
+++ b/pkg/multiwerf/self-update.go
@@ -43,7 +43,7 @@ func SelfUpdate(messages chan ActionMessage) string {
 
 	btClient := bintray.NewBintrayClient(app.SelfBintraySubject, app.SelfBintrayRepo, app.SelfBintrayPackage)
 
-	pkgInfo, err := btClient.GetPackage()
+	pkgInfo, err := btClient.GetPackageInfo()
 	if err != nil {
 		messages <- ActionMessage{
 			comment: "self update error",

--- a/pkg/multiwerf/self-update.go
+++ b/pkg/multiwerf/self-update.go
@@ -4,36 +4,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/flant/multiwerf/pkg/app"
 	"github.com/flant/multiwerf/pkg/bintray"
-	"strings"
 )
 
 var multiwerfProlog = fmt.Sprintf("%s %s self-update", app.AppName, app.Version)
 
 // SelfUpdate checks for new version of multiwerf, download it and execute as a new process.
 // Note: multiwerf has no option to exit on self-update errors.
-func SelfUpdate(messages chan ActionMessage) {
-	selfPath := ""
-	if app.SelfUpdate == "yes" {
-		selfPath = DoSelfUpdate(messages)
-	}
-	if selfPath != "" {
-		err := ExecUpdatedBinary(selfPath)
-		if err != nil {
-			messages <- ActionMessage{
-				comment: "self update error",
-				msg:     fmt.Sprintf("%s: exec of updated binary failed: %v", multiwerfProlog, err),
-				msgType: "fail",
-				stage:   "self-update"}
-		}
-	}
-}
-
-func DoSelfUpdate(messages chan ActionMessage) string {
-	// TODO check executable is writable and stop self update if it is not.
+func SelfUpdate(messages chan ActionMessage) string {
+	// TODO check if executable is writable and stop self update if it is not.
 	selfPath, err := GetSelfExecutableInfo()
 	if err != nil {
 		messages <- ActionMessage{
@@ -45,11 +28,11 @@ func DoSelfUpdate(messages chan ActionMessage) string {
 	err = CheckIsFileWritable(selfPath)
 	if err != nil {
 		messages <- ActionMessage{
-			msg:   fmt.Sprintf("%s: check is writable error: %v", multiwerfProlog, err),
+			msg:   fmt.Sprintf("%s: check for writable file error: %v", multiwerfProlog, err),
 			debug: true}
 		messages <- ActionMessage{
 			comment: "self update warning",
-			msg:     fmt.Sprintf("Multiwerf self-update is disabled. Executable file is not writable."),
+			msg:     fmt.Sprintf("Skip self-update: executable file is not writable."),
 			msgType: "warn",
 			stage:   "self-update"}
 		return ""
@@ -125,7 +108,7 @@ func DoSelfUpdate(messages chan ActionMessage) string {
 		debug: true}
 
 	messages <- ActionMessage{msg: fmt.Sprintf("%s: start downloading", multiwerfProlog), debug: true}
-	err = btClient.DownloadRelease(latestVersion, selfDir, downloadFiles)
+	err = btClient.DownloadFiles(latestVersion, selfDir, downloadFiles)
 	if err != nil {
 		messages <- ActionMessage{
 			comment: "self update error",
@@ -136,7 +119,7 @@ func DoSelfUpdate(messages chan ActionMessage) string {
 	}
 
 	// TODO add hash verification!
-	sha256sums, err := btClient.FetchReleaseFile(latestVersion, files["hash"])
+	sha256sums, err := btClient.GetFileContent(latestVersion, files["hash"])
 	if err != nil {
 		messages <- ActionMessage{
 			comment: "self update error",

--- a/pkg/multiwerf/update.go
+++ b/pkg/multiwerf/update.go
@@ -482,7 +482,7 @@ func DownloadVersion(version string, messages chan ActionMessage, btClient bintr
 
 	messages <- ActionMessage{msg: "Start downloading", debug: true}
 
-	err = btClient.DownloadRelease(version, dstPath, files)
+	err = btClient.DownloadFiles(version, dstPath, files)
 	if err != nil {
 		return err
 	}

--- a/pkg/multiwerf/update_test.go
+++ b/pkg/multiwerf/update_test.go
@@ -18,7 +18,7 @@ func Test_GetBinaryInfo(t *testing.T) {
 	var err error
 
 	go func() {
-		info, err = GetBinaryInfo("v1.0.1-beta.9", msgsCh)
+		info, err = GetVerifiedBinaryInfo("v1.0.1-beta.9", msgsCh)
 		msgsCh <- ActionMessage{
 			action: "exit",
 		}

--- a/pkg/util/rndstr.go
+++ b/pkg/util/rndstr.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	"math/rand"
+	"strconv"
+	"time"
+)
+
+// RndDigigtsStr returns random string with digits
+func RndDigitsStr(len int) string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var res int32
+	for i := 0; i < len; i++ {
+		digit := r.Int31n(10)
+		res = res*10 + digit
+	}
+	return strconv.FormatInt(int64(res), 10)
+}


### PR DESCRIPTION
- locks for remote actions between update and use commands
- fix download release process: create version directory in storage only if all ok
- download is ok only if binary and checksum are downloaded and hash is verified
- if download is bad — use latest local version
- remove empty path message introduced in v1.0.13
- fix delays update
- use command doesn't verify a hash of local version if --update=no